### PR TITLE
refs #28 微修正２件（不要なstateの削除、詳細画面から一覧画面に戻る動線を追加）

### DIFF
--- a/webapp/app/javascript/packs/components/AlbumFormSelectComponent.js
+++ b/webapp/app/javascript/packs/components/AlbumFormSelectComponent.js
@@ -4,12 +4,8 @@ import PropTypes from 'prop-types';
 import Form from './AlbumFormComponent';
 
 export default class Album extends Component {
-  constructor(props) {
+  constructor() {
     super();
-    this.state = {
-      name: '',
-      image_urls: props.ficker_images
-    };
   }
 
   componentDidMount() {

--- a/webapp/app/javascript/packs/components/AlbumShowComponent.js
+++ b/webapp/app/javascript/packs/components/AlbumShowComponent.js
@@ -15,6 +15,10 @@ export default class AlbumShow extends Component {
     this.props.deleteImage(image_id);
   }
 
+  moveToIndex() {
+    location.href='/';
+  }
+
   imageList() {
     const images = this.props.album && this.props.album.album_images || [];
     const imageList = images.map((image) =>
@@ -41,6 +45,9 @@ export default class AlbumShow extends Component {
         <section className="container__wrap">
           <div className="header">
             <h2 className="heading">アルバム詳細</h2>
+            <button onClick={() => this.moveToIndex()} className="btn__base">
+              一覧に戻る
+            </button>
           </div>
           <h3>アルバム名：{this.props.album && this.props.album.name}</h3>
           <div>{this.imageList()}</div>


### PR DESCRIPTION
詳細画面には下記の２通りの遷移がある

　1. 一覧画面から詳細ボタンを押して遷移
　2. 作成・更新画面でアルバムを作成・更新した後のリダイレクト

1. の場合にはブラウザバックで戻れる
（アルバム自体の削除や名前の変更ができないので
　キャッシュで過去の情報が出てても問題ない）

2. の場合には戻るボタンだと編集画面に戻るから一覧に移動したい時に困る

そのため動線を追加